### PR TITLE
fix(composer): Do not require PHP 7.1 with old omnipay dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "omnipay/common": "3.0-beta.1",
+        "omnipay/common": "^3.0",
         "php-http/guzzle6-adapter": "^1.1"
     },
     "require-dev": {
-        "omnipay/tests": "3.0-beta.1"
+        "omnipay/tests": "^3.0"
     },
     "autoload": {
         "psr-4": { "Omnipay\\Eghl\\" : "src/" }


### PR DESCRIPTION
Installation with composer on PHP 7.0 fails:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - dilab/omnipay-eghl 2.0.0 requires omnipay/common 3.0-beta.1 -> satisfiable by omnipay/common[v3.0-beta.1].
    - dilab/omnipay-eghl 2.0.1 requires omnipay/common 3.0-beta.1 -> satisfiable by omnipay/common[v3.0-beta.1].
    - dilab/omnipay-eghl 2.0.2 requires omnipay/common 3.0-beta.1 -> satisfiable by omnipay/common[v3.0-beta.1].
    - dilab/omnipay-eghl 2.0.3 requires omnipay/common 3.0-beta.1 -> satisfiable by omnipay/common[v3.0-beta.1].
    - omnipay/common v3.0-beta.1 requires php ^7.1 -> your PHP version (7.0.30) does not satisfy that requirement.
    - Installation request for dilab/omnipay-eghl ^2 -> satisfiable by dilab/omnipay-eghl[2.0.0, 2.0.1, 2.0.2, 2.0.3].
```

We should not hard-code beta1 as fixed version, 3.0.2 is out now and only requires PHP >7. https://packagist.org/packages/omnipay/common